### PR TITLE
HTTPS endpoint + pruning

### DIFF
--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -2,7 +2,7 @@
 
 class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Import_Abstract
 {
-    protected $_url = 'http://api.fixer.io/latest?base=%1$s&symbols=%2$s';
+    protected $_url = 'https://api.fixer.io/latest?base=%1$s&symbols=%2$s';
     protected $_messages = array();
 
      /**
@@ -35,7 +35,7 @@ class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Impo
                 $this->_messages[] = Mage::helper('directory')->__('Cannot retrieve rate from %s.', $url);
                 return null;
             }
-            
+
             // test for bcmath to retain precision
             if (function_exists('bcadd')) {
                 return bcadd($rate, '0', 12);

--- a/app/code/community/Philwinkle/Fixerio/Model/Observer.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Observer.php
@@ -1,8 +1,0 @@
-<?php
-
-class Philwinkle_Fixerio_Model_Observer
-{
-
-
-}
-

--- a/app/code/community/Philwinkle/Fixerio/etc/config.xml
+++ b/app/code/community/Philwinkle/Fixerio/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Philwinkle_Fixerio>
-             <version>0.2.0</version>
+             <version>0.3.0</version>
         </Philwinkle_Fixerio>
     </modules>
     <global>

--- a/app/code/community/Philwinkle/Fixerio/etc/config.xml
+++ b/app/code/community/Philwinkle/Fixerio/etc/config.xml
@@ -5,8 +5,6 @@
              <version>0.2.0</version>
         </Philwinkle_Fixerio>
     </modules>
-    <admin>
-    </admin>
     <global>
         <currency>
             <import>
@@ -21,7 +19,6 @@
         <models>
             <fixerio>
                 <class>Philwinkle_Fixerio_Model</class>
-                <resourceModel>fixerio_entity</resourceModel>
             </fixerio>
         </models>
         <helpers>

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,6 @@
   "license": "MIT",
   "type": "magento-module",
   "description": "This module adds the Fixer.io webservice to the list of available currency conversion webservices in Magento.",
-  "require": {
-    "magento-hackathon/magento-composer-installer": "*"
-  },
   "authors": [
     {
       "name": "Phillip Jackson",


### PR DESCRIPTION
- Fixer.io API endpoint changed to consume HTTPS
- Remove dependancy on Magento Composer Installer - Allows consumers to choose their composer installer.
- Bumped module version number to `0.3.0` and removed un-used code & config XML nodes.

Hope these changes are useful!
