### PR TITLE
Updated module version to make a new release

### DIFF
--- a/app/code/community/Philwinkle/Fixerio/etc/config.xml
+++ b/app/code/community/Philwinkle/Fixerio/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Philwinkle_Fixerio>
-             <version>0.3.0</version>
+             <version>0.4.1</version>
         </Philwinkle_Fixerio>
     </modules>
     <global>


### PR DESCRIPTION
i used 0.4.1 instead of 0.4.0, so you can make a new git release tag.