### PR TITLE
Makes the module compatible with Magento 1.9.4.3+

### DIFF
--- a/app/code/community/Philwinkle/Fixerio/Helper/Data.php
+++ b/app/code/community/Philwinkle/Fixerio/Helper/Data.php
@@ -2,7 +2,4 @@
 
 class Philwinkle_Fixerio_Helper_Data extends Mage_Core_Helper_Abstract
 {
-
-
 }
-

--- a/app/code/community/Philwinkle/Fixerio/Model/Base.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Base.php
@@ -1,0 +1,10 @@
+<?php
+
+//For Magento 1.9.4.3+ this model will extend Magento's implementation, which in turn extends the abstract class
+//For older Magento versions, this model extends the abstract class directly, as there is no Magento implementation
+//to extend
+if (class_exists('Mage_Directory_Model_Currency_Import_Fixerio')) {
+    abstract class Philwinkle_Fixerio_Model_Base extends Mage_Directory_Model_Currency_Import_Fixerio {}
+} else {
+    abstract class Philwinkle_Fixerio_Model_Base extends Mage_Directory_Model_Currency_Import_Abstract {}
+}

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -21,6 +21,16 @@ if (class_exists('Mage_Directory_Model_Currency_Import_Fixerio')) {
  */
 class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Base
 {
+    /**
+     * XML path to Fixer.IO timeout setting
+     */
+    const XML_PATH_FIXERIO_TIMEOUT = 'currency/fixerio/timeout';
+
+    /**
+     * XML path to Fixer.IO API key setting
+     */
+    const XML_PATH_FIXERIO_API_KEY = 'currency/fixerio/api_key';
+
     protected $_url = 'http://data.fixer.io/api/latest';
     protected $_messages = [];
 
@@ -34,23 +44,6 @@ class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Ba
     public function __construct()
     {
         $this->_httpClient = new Varien_Http_Client();
-    }
-
-    /**
-     * _getConfigAccessKey
-     *
-     * @return bool|mixed
-     */
-    protected function _getConfigAccessKey()
-    {
-        if ($accessKey = Mage::helper('core')->decrypt(Mage::getStoreConfig('currency/fixerio/api_key'))) {
-            return $accessKey;
-        }
-
-        $this->_messages[] = Mage::helper('directory')
-            ->__('Fixer.io access key missing.  Please obtain access key from fixer.io.');
-
-        return false;
     }
 
     /**
@@ -94,7 +87,7 @@ class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Ba
 
             $response = $this->_httpClient
                 ->setUri($url)
-                ->setConfig(array('timeout' => Mage::getStoreConfig('currency/fixerio/timeout')))
+                ->setConfig(array('timeout' => Mage::getStoreConfig(self::XML_PATH_FIXERIO_TIMEOUT)))
                 ->request('GET')
                 ->getBody();
 
@@ -132,5 +125,23 @@ class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Ba
         }
 
         return null;
+    }
+
+    /**
+     * _getConfigAccessKey
+     *
+     * @return bool|mixed
+     */
+    protected function _getConfigAccessKey()
+    {
+        $accessKey = Mage::helper('core')->decrypt(Mage::getStoreConfig(self::XML_PATH_FIXERIO_API_KEY));
+        if ($accessKey) {
+            return $accessKey;
+        }
+
+        $this->_messages[] = Mage::helper('directory')
+            ->__('Fixer.io access key missing. Please obtain it from fixer.io.');
+
+        return false;
     }
 }

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -4,22 +4,13 @@
  *
  */
 
-//For Magento 1.9.4.3+ this model will extend Magento's implementation, which in turn extends the abstract class
-//For older Magento versions, this model extends the abstract class directly, as there is no Magento implementation
-//to extend
-if (class_exists('Mage_Directory_Model_Currency_Import_Fixerio')) {
-    abstract class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Fixerio {}
-} else {
-    abstract class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Abstract {}
-}
-
 /**
  * Philwinkle_Fixerio_Model_Import class
  *
  * @category    Philwinkle
  * @package     Philwinkle_Fixerio
  */
-class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Base
+class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Base
 {
     /**
      * XML path to Fixer.IO timeout setting

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -4,17 +4,25 @@
  *
  */
 
+//For Magento 1.9.4.3+ this model will extend Magento's implementation, which in turn extends the abstract class
+//For older Magento versions, this model extends the abstract class directly, as there is no Magento implementation
+//to extend
+if (class_exists('Mage_Directory_Model_Currency_Import_Fixerio')) {
+    class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Fixerio {}
+} else {
+    class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Abstract {}
+}
+
 /**
  * Philwinkle_Fixerio_Model_Import class
  *
  * @category    Philwinkle
  * @package     Philwinkle_Fixerio
  */
-class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Import_Abstract
+class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Base
 {
-
     protected $_url = 'http://data.fixer.io/api/latest';
-    protected $_messages = array();
+    protected $_messages = [];
 
     /**
      * HTTP client
@@ -119,5 +127,4 @@ class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Impo
 
         return null;
     }
-
 }

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -35,7 +35,7 @@ class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Impo
      */
     protected function _getConfigAccessKey()
     {
-        if ($accessKey = Mage::helper('core')->decrypt(Mage::getStoreConfig('currency/fixerio/access_key'))) {
+        if ($accessKey = Mage::helper('core')->decrypt(Mage::getStoreConfig('currency/fixerio/api_key'))) {
             return $accessKey;
         }
 
@@ -66,7 +66,6 @@ class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Impo
      */
     protected function _convert($currencyFrom, $currencyTo, $retry = 0)
     {
-
         $queryParams = array(
             'access_key' => $this->_getConfigAccessKey(),
             'symbols'    => implode(',', array($currencyFrom, $currencyTo))

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -8,9 +8,9 @@
 //For older Magento versions, this model extends the abstract class directly, as there is no Magento implementation
 //to extend
 if (class_exists('Mage_Directory_Model_Currency_Import_Fixerio')) {
-    class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Fixerio {}
+    abstract class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Fixerio {}
 } else {
-    class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Abstract {}
+    abstract class Philwinkle_Fixerio_Model_Import_Base extends Mage_Directory_Model_Currency_Import_Abstract {}
 }
 
 /**

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -63,6 +63,12 @@ class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Ba
         return $this->_url;
     }
 
+    public function fetchRates()
+    {
+        //Make sure to disable Magento's implementation by invoking the implementation in the abstract class
+        return Mage_Directory_Model_Currency_Import_Abstract::fetchRates();
+    }
+
     /**
      * _convert
      *

--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -118,7 +118,7 @@ class Philwinkle_Fixerio_Model_Import extends Philwinkle_Fixerio_Model_Import_Ba
         } catch (Exception $e) {
             Mage::logException($e);
             if ($retry === 0) {
-                return $this->_convert($currencyFrom, $currencyTo, 1);
+                return $this->_convert($currencyFrom, $currencyTo, $retry + 1);
             }
 
             $this->_messages[] = Mage::helper('directory')->__('Cannot retrieve rate from %s.', $url);

--- a/app/code/community/Philwinkle/Fixerio/etc/config.xml
+++ b/app/code/community/Philwinkle/Fixerio/etc/config.xml
@@ -30,8 +30,9 @@
     <default>
         <currency>
             <fixerio>
-                <timeout>60</timeout>
-                <access_key></access_key>
+                <timeout>100</timeout>
+                <api_key backend_model="adminhtml/system_config_backend_encrypted"/>
+                <active>1</active>
             </fixerio>
         </currency>
     </default>

--- a/app/code/community/Philwinkle/Fixerio/etc/config.xml
+++ b/app/code/community/Philwinkle/Fixerio/etc/config.xml
@@ -10,7 +10,7 @@
             <import>
                 <services>
                     <fixerio>
-                        <name>Fixer.io</name>
+                        <name>Fixer.IO</name>
                         <model>fixerio/import</model>
                     </fixerio>
                 </services>
@@ -20,6 +20,15 @@
             <fixerio>
                 <class>Philwinkle_Fixerio_Model</class>
             </fixerio>
+            <directory>
+                <rewrite>
+                    <!--
+                    In Magento versions 1.9.4.3+ this module's implementation rewrites Magento's one, in case someone
+                    tries to get an instance of that model directly
+                    -->
+                    <currency_import_fixerio>Philwinkle_Fixerio_Model_Import</currency_import_fixerio>
+                </rewrite>
+            </directory>
         </models>
         <helpers>
             <fixerio>

--- a/app/code/community/Philwinkle/Fixerio/etc/system.xml
+++ b/app/code/community/Philwinkle/Fixerio/etc/system.xml
@@ -10,24 +10,33 @@
                     <show_in_website>0</show_in_website>
                     <show_in_store>0</show_in_store>
                     <fields>
-                        <timeout translate="label">
-                            <label>Connection Timeout in Seconds</label>
-                            <frontend_type>text</frontend_type>
+                        <active translate="label">
+                            <label>Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>0</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </timeout>
-                        <access_key translate="label">
-                            <label>API Access Key from fixer.io</label>
-                            <comment><![CDATA[Sign up for a free account at <a href="https://fixer.io/signup/free" target="_blank">Fixer.io</a>]]></comment>
-                            <frontend_type>obscure</frontend_type>
-                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
-                            <sort_order>1</sort_order>
+                        </active>
+                        <timeout translate="label">
+                            <label>Connection Timeout in Seconds</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>10</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </access_key>
+                        </timeout>
+                        <api_key translate="label">
+                            <label>API Access Key</label>
+                            <comment><![CDATA[Sign up for a free account at <a href="https://fixer.io/signup/free" target="_blank">Fixer.io</a>]]></comment>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </api_key>
                     </fields>
                 </fixerio>
             </groups>


### PR DESCRIPTION
See #33

This PR updates the module to take into account Magento's own implementation of the FixerIO integration.

The main model in this module was changed to be a rewrite of Magento's implementation (when this is present), and the extension configuration was changed to mirror Magento's. Basically, this module replaces Magento's implementation for versions 1.9.4.3 and above and provides an implementation that was not present for Magento versione below that one.

The only drawback that I can see is that the system config field for the api key was renamed from access_key to api_key. So if someone upgrades this module from an older version to one including this PR, he/she would have to re-enter the API key value in the configuration field, otherwise the module would not work.