### PR TITLE
get pure json response

### DIFF
--- a/app/code/community/Philwinkle/Fixerio/Model/Import.php
+++ b/app/code/community/Philwinkle/Fixerio/Model/Import.php
@@ -83,7 +83,7 @@ class Philwinkle_Fixerio_Model_Import extends Mage_Directory_Model_Currency_Impo
                 ->setUri($url)
                 ->setConfig(array('timeout' => Mage::getStoreConfig('currency/fixerio/timeout')))
                 ->request('GET')
-                ->getBody();
+                ->getRowBody();
 
             /** Second parameter is objectDecodeType - Zend_Json::TYPE_ARRAY, or Zend_Json::TYPE_OBJECT */
             $converted = Mage::helper('core')->jsonDecode($response, Zend_Json::TYPE_ARRAY);


### PR DESCRIPTION
I have faced issue many times that getBody function is not working, beacuse here in response of fixer.io api, its sending chunked body, but in not correct formate as per magento, so I have get just RawBody not parsed.